### PR TITLE
Override transition from full wrapper

### DIFF
--- a/site/src/main/resources/microsite/css/overrides.css
+++ b/site/src/main/resources/microsite/css/overrides.css
@@ -15,3 +15,8 @@ table {
     -webkit-transition: none;
     transition: none;
 }
+
+#wrapper {
+    -webkit-transition: none;
+    transition: none;
+}


### PR DESCRIPTION
As it was removed from the sidebar, to avoid the transition effect completely, the easing must be also overwritten in the full content wrapper too.