### PR TITLE
Fix micrositeGitterChannelURL

### DIFF
--- a/site.sbt
+++ b/site.sbt
@@ -15,7 +15,7 @@ lazy val siteSettings = Seq(
   micrositeHighlightTheme := "atom-one-light",
   micrositeDocumentationUrl := "/docs",
   micrositeGitterChannel := true,
-  micrositeGitterChannelUrl := "temperature-machine",
+  micrositeGitterChannelUrl := "temperature-machine/Lobby",
   micrositeAnalyticsToken := "UA-3327317-12",
 
   micrositeFavicons := Seq(


### PR DESCRIPTION
* Set the Gitter channel URL to an specific room, in this case the 'Lobby' from temperature-machine org.